### PR TITLE
Hi Kevin, please add this minor tweak to make Sonar happier! :)

### DIFF
--- a/bioportal-service/pom.xml
+++ b/bioportal-service/pom.xml
@@ -8,6 +8,7 @@
 		<version>0.4.9-SNAPSHOT</version>
 	</parent>
 	
+	<groupId>edu.mayo.cts2.framework</groupId>
 	<artifactId>bioportal-service</artifactId>
 	<version>0.4.5-SNAPSHOT</version>
 	<name>bioportal-service</name>


### PR DESCRIPTION
Without groupId specified, tools like Sonar get confused - they use "null" groupId instead.
